### PR TITLE
Specify Python version in installation guide

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@
     <pre><code class="language-bash">source $HOME/miniconda2/bin/activate root  # Linux / macOS
 activate root                              # Windows
 
-conda create -n py2_parcels -c conda-forge parcels jupyter basemap basemap-data-hires</code></pre></li>
+conda create -n py2_parcels -c conda-forge python=2.7 parcels jupyter basemap basemap-data-hires</code></pre></li>
 
     <li>Activate the newly created Parcels environment, get a copy of the the Parcels tutorials and examples, and run the simplest of the examples to validate that you have a working Parcels setup:
     <pre><code class="language-bash">source $HOME/miniconda2/bin/activate py2_parcels  # Linux / macOS


### PR DESCRIPTION
With the Python-3 package being added to the conda-forge channel, `conda create` needs to be more specific about the Python version.  Otherwise, the environment will go for the latest compatible set of versions.

I am strongly in favor of moving the installation instructions to Python 3 though.  So consider this PR a short-term fix to make sure users get what they expect when following the guide.