### PR TITLE
Include ffmpeg to explicitly installed packages

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,11 +143,11 @@
   <ol>
     <li>Install Anaconda's Miniconda following the steps at <a href="https://conda.io/docs/user-guide/install/">https://conda.io/docs/user-guide/install/</a>.  All the code below assumes that you download the Python-2 version, although Parcels also works with Python-3.  If you're on Linux / macOS, it also assumes that you installed Miniconda-2 to your home directory.</li>
     <p></p>
-    <li>Start a terminal (Linux / macOS) or the Anaconda prompt (Windows). Activate the root (or base) environment of your Miniconda and create an environment containing Parcels, all its essential dependencies, and the nice-to-have Jupyter and cartopy package:
+    <li>Start a terminal (Linux / macOS) or the Anaconda prompt (Windows). Activate the root (or base) environment of your Miniconda and create an environment containing Parcels, all its essential dependencies, and the nice-to-have Jupyter, cartopy, and ffmpeg packages:
     <pre><code class="language-bash">source $HOME/miniconda2/bin/activate root  # Linux / macOS
 activate root                              # Windows
 
-conda create -n py2_parcels -c conda-forge python=2.7 parcels jupyter cartopy</code></pre></li>
+conda create -n py2_parcels -c conda-forge python=2.7 parcels jupyter cartopy ffmpeg</code></pre></li>
     <p></p>
     <li>Activate the newly created Parcels environment.
       <pre><code class="language-bash">source $HOME/miniconda2/bin/activate py2_parcels  # Linux / macOS


### PR DESCRIPTION
This accounts for https://github.com/conda-forge/parcels-feedstock/pull/30 which lead us to loosen the matplotlib requirement and drop ffmpeg from the dependencies as it's only related to an optional functionality.