### PR TITLE
Parcels2.0 update

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -123,7 +123,7 @@ fset = FieldSet.from_netcdf(filenames, variables, dimensions)</code></pre>
   <p></p>
   However, there are some key limitations to the Kernels that everyone who wants to write their own should be aware of:
   <ul>
-    <li>Every Kernel must be a function with the following (and only those) arguments: <code class="language-python">(particle, fieldset, time, dt)</code></li>
+    <li>Every Kernel must be a function with the following (and only those) arguments: <code class="language-python">(particle, fieldset, time)</code></li>
 
     <li>In order to run successfully in JIT mode, Kernel definitions can only contain the following types of commands:</li>
     <ul>
@@ -133,9 +133,9 @@ fset = FieldSet.from_netcdf(filenames, variables, dimensions)</code></pre>
 
       <li><code class="language-python">if</code> and <code class="language-python">while</code> loops, as well as <code class="language-python">break</code> statements. Note that <code class="language-python">for</code>-loops are not supported in JIT mode</li>
 
-      <li>Interpolation of a <code class="language-python">Field</code> from the <code class="language-python">FieldSet</code> at a <code class="language-python">(time, lon, lat, depth)</code> point, using using square brackets notation. For example, to interpolate the zonal velocity (U) field at the particle location, use the following statement:<br>
+      <li>Interpolation of a <code class="language-python">Field</code> from the <code class="language-python">FieldSet</code> at a <code class="language-python">(time, depth, lat, lon)</code> point, using using square brackets notation. <br><b>Note that from version 2.0, the syntax has changed from the old (time, lon, lat, depth) to the new (time, depth, lat, lon) order</b>.<br> For example, to interpolate the zonal velocity (U) field at the particle location, use the following statement:<br>
 
-        <pre><code class="language-python">value = fieldset.U[time, particle.lon, particle.lat, particle.depth]</code></pre></li>
+        <pre><code class="language-python">value = fieldset.U[time, particle.depth, particle.lat, particle.lon]</code></pre></li>
 
       <li>Functions from the <code class="language-python">maths</code> standard library and from the custom <code class="language-python">random</code> library at <code class="language-python">parcels.rng</code></li>
 

--- a/faq.html
+++ b/faq.html
@@ -123,7 +123,7 @@ fset = FieldSet.from_netcdf(filenames, variables, dimensions)</code></pre>
   <p></p>
   However, there are some key limitations to the Kernels that everyone who wants to write their own should be aware of:
   <ul>
-    <li>Every Kernel must be a function with the following (and only those) arguments: <code class="language-python">(particle, fieldset, time)</code></li>
+    <li>Every Kernel must be a function with the following (and only those) arguments: <code class="language-python">(particle, fieldset, time)</code> <i>(note that before Parcels v2.0, Kernels also required a <code class="language-python">dt</code> argument)</i></li>
 
     <li>In order to run successfully in JIT mode, Kernel definitions can only contain the following types of commands:</li>
     <ul>

--- a/index.html
+++ b/index.html
@@ -301,7 +301,7 @@ python setup.py install</code></pre>
   <hr>
 
   <h2 id="developmentstatus">Parcels development status</h2>
-  The current release of Parcels, version 1.0.2, is a fully-functional, feature-complete code for offline Lagrangian ocean analysis. See below for a list of features, or keep an eye on the <a href="https://github.com/OceanParcels/parcels/projects/1">Github Development Timeline page</a>
+  The current release of Parcels, version 2.0beta, is a fully-functional, feature-complete code for offline Lagrangian ocean analysis. See below for a list of features, or keep an eye on the <a href="https://github.com/OceanParcels/parcels/projects/1">Github Development Timeline page</a>
   <p></p>
   <h4>Major features</h4>
   <div class="card-columns">

--- a/index.html
+++ b/index.html
@@ -141,17 +141,17 @@
   The steps below are the installation instructions for Linux / macOS and for Windows.  If the commands for Linux / macOS and Windows differ, this is indicated with a comment at the end of the line.
   <p></p>
   <ol>
-    <li>Install Anaconda's Miniconda following the steps at <a href="https://conda.io/docs/user-guide/install/">https://conda.io/docs/user-guide/install/</a>.  All the code below assumes that you download the Python-2 version, although Parcels also works with Python-3.  If you're on Linux / macOS, it also assumes that you installed Miniconda-2 to your home directory.</li>
+    <li>Install Anaconda's Miniconda following the steps at <a href="https://conda.io/docs/user-guide/install/">https://conda.io/docs/user-guide/install/</a>.  All the code below assumes that you download the Python-3 version, although Parcels also works with Python-2.  If you're on Linux / macOS, it also assumes that you installed Miniconda-3 to your home directory.</li>
     <p></p>
     <li>Start a terminal (Linux / macOS) or the Anaconda prompt (Windows). Activate the root (or base) environment of your Miniconda and create an environment containing Parcels, all its essential dependencies, and the nice-to-have Jupyter, cartopy, and ffmpeg packages:
-    <pre><code class="language-bash">source $HOME/miniconda2/bin/activate root  # Linux / macOS
+    <pre><code class="language-bash">source $HOME/miniconda3/bin/activate root  # Linux / macOS
 activate root                              # Windows
 
-conda create -n py2_parcels -c conda-forge python=2.7 parcels jupyter cartopy ffmpeg</code></pre></li>
+conda create -n py3_parcels -c conda-forge python=3.6 parcels jupyter cartopy ffmpeg</code></pre></li>
     <p></p>
     <li>Activate the newly created Parcels environment.
-      <pre><code class="language-bash">source $HOME/miniconda2/bin/activate py2_parcels  # Linux / macOS
-activate py2_parcels                              # Windows</code></pre></li>
+      <pre><code class="language-bash">source $HOME/miniconda3/bin/activate py3_parcels  # Linux / macOS
+activate py3_parcels                              # Windows</code></pre></li>
     <li>Get a copy of the Parcels tutorials and examples, and run the simplest of the examples to validate that you have a working Parcels setup:
     <pre><code class="language-bash">parcels_get_examples parcels_examples
 cd parcels_examples
@@ -163,8 +163,8 @@ python example_peninsula.py --fieldset 100 100</code></pre></li>
     <pre><code class="language-bash">jupyter notebook</code></pre></li>
     <p></p>
     <li>The next time you start a terminal and want to work with Parcels, activate the environment with:
-    <pre><code class="language-bash">source $HOME/miniconda2/bin/activate py2_parcels  # Linux / macOS
-activate py2_parcels                              # Windows</code></pre></li>
+    <pre><code class="language-bash">source $HOME/miniconda3/bin/activate py3_parcels  # Linux / macOS
+activate py3_parcels                              # Windows</code></pre></li>
   </ol>
 
   <h4>Installing a non-released version of Parcels</h4>
@@ -172,8 +172,8 @@ activate py2_parcels                              # Windows</code></pre></li>
     There might be cases where you want to install a version of Parcels that has not been released yet.  (Perhaps, if you want to use a bleeding-edge feature which already is included on Github, but not in the conda-forge package.)
 
   Then, just after step 2 of <a href="#installing">Installing Parcels</a> above, use the following commands to remove the conda-forge package again, and use <code>pip</code> to install Parcels from Github:
-    <pre><code class="language-bash">source $HOME/miniconda2/bin/activate py2_parcels  # Linux / macOS
-activate py2_parcels                              # Windows
+    <pre><code class="language-bash">source $HOME/miniconda3/bin/activate py3_parcels  # Linux / macOS
+activate py3_parcels                              # Windows
 
 conda remove parcels
 pip install git+https://github.com/OceanParcels/parcels.git@master
@@ -181,8 +181,8 @@ python setup.py install</code></pre>
 
   <h4>Installation for developers</h4>
 
-  Parcels depends on a working Python installation, a netCDF installation, a C compiler, and various Python packages.  If you prefer to maintain your own Python installation providing all this, <code class="language-bash">git clone</code> the <a href="https://github.com/OceanParcels/parcels">master branch of Parcels</a> and manually install all packages listed under <code>dependencies</code> in the environment files (<a href="https://raw.githubusercontent.com/OceanParcels/parcels/master/environment_py2_linux.yml">environment_py2_linux.yml</a> for Linux, <a href="https://raw.githubusercontent.com/OceanParcels/parcels/master/environment_py2_osx.yml">environment_py2_osx.yml</a> for OSX and
-    <a href="https://raw.githubusercontent.com/OceanParcels/parcels/master/environment_py2_win.yml">environment_py2_win.yml</a> for Windows), before running <code class="language-bash">python setup.py install</code>.
+  Parcels depends on a working Python installation, a netCDF installation, a C compiler, and various Python packages.  If you prefer to maintain your own Python installation providing all this, <code class="language-bash">git clone</code> the <a href="https://github.com/OceanParcels/parcels">master branch of Parcels</a> and manually install all packages listed under <code>dependencies</code> in the environment files (<a href="https://raw.githubusercontent.com/OceanParcels/parcels/master/environment_py3_linux.yml">environment_py3_linux.yml</a> for Linux, <a href="https://raw.githubusercontent.com/OceanParcels/parcels/master/environment_py3_osx.yml">environment_py3_osx.yml</a> for OSX and
+    <a href="https://raw.githubusercontent.com/OceanParcels/parcels/master/environment_py3_win.yml">environment_py3_win.yml</a> for Windows), before running <code class="language-bash">python setup.py install</code>.
 
   <hr>
   <h2 id="tutorials">Parcels tutorials</h2>

--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@
     <pre><code class="language-bash">source $HOME/miniconda3/bin/activate root  # Linux / macOS
 activate root                              # Windows
 
-conda create -n py3_parcels -c conda-forge python=3.6 parcels jupyter cartopy ffmpeg</code></pre></li>
+conda create -n py3_parcels -c conda-forge python=3 parcels jupyter cartopy ffmpeg</code></pre></li>
     <p></p>
     <li>Activate the newly created Parcels environment.
       <pre><code class="language-bash">source $HOME/miniconda3/bin/activate py3_parcels  # Linux / macOS
@@ -301,7 +301,7 @@ python setup.py install</code></pre>
   <hr>
 
   <h2 id="developmentstatus">Parcels development status</h2>
-  The current release of Parcels, version 2.0beta, is a fully-functional, feature-complete code for offline Lagrangian ocean analysis. See below for a list of features, or keep an eye on the <a href="https://github.com/OceanParcels/parcels/projects/1">Github Development Timeline page</a>
+  The current release of Parcels, version 2.0.0-beta, is a fully-functional, feature-complete code for offline Lagrangian ocean analysis. See below for a list of features, or keep an eye on the <a href="https://github.com/OceanParcels/parcels/projects/1">Github Development Timeline page</a>
   <p></p>
   <h4>Major features</h4>
   <div class="card-columns">


### PR DESCRIPTION
Updating the website for the new Parcels v2.0. Specifically
- Change to python3 as default installation
- Note about changed interpolation order in kernels and their definitions