### PR TITLE
Don't run setup.py if installing with pip

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,7 +201,7 @@ activate py3_parcels                              # Windows
 
 conda remove parcels
 pip install git+https://github.com/OceanParcels/parcels.git@master
-python setup.py install</code></pre>
+</code></pre>
 
   <h4>Installation for developers</h4>
 


### PR DESCRIPTION
This removes an unnecessary line from the installation instructions for installing an unreleased version.