### PR TITLE
add github links

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,7 +265,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
   <hr>
   <h2 id="tutorials">Parcels tutorials</h2>
 
-  The best way to get started with Parcels is to explore the Jupyter notebooks below. By clicking on the tutorials you can read them on the Jupyter notebook viewer. If you want to practice by interacting with them, you can either visit <a href="https://mybinder.org/v2/gh/OceanParcels/parcels_examples_binder/master?urlpath=lab/tree/parcels_examples/parcels_tutorial.ipynb">mybinder.org</a> or run them on your own device if you have installed them with <code class="language-bash">parcels_get_examples parcels_examples</code> (see 4. in the <a href="#installing"> installation</a>).
+  The best way to get started with Parcels is to explore the Jupyter notebooks below. By clicking on the tutorials you can read them on the Jupyter notebook viewer. Due to some issues with the GitHub API some notebooks are temporarily not found, resulting in a 404 Error. Please find the corresponding notebook file by clicking the GitHub tag in the card. If you want to practice by interacting with them, you can either visit <a href="https://mybinder.org/v2/gh/OceanParcels/parcels_examples_binder/master?urlpath=lab/tree/parcels_examples/parcels_tutorial.ipynb">mybinder.org</a> or run them on your own device if you have installed them with <code class="language-bash">parcels_get_examples parcels_examples</code> (see 4. in the <a href="#installing"> installation</a>).
 
   <p></p>
   <div class="row">
@@ -285,6 +285,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card-footer">
           <img src="https://img.shields.io/badge/level-beginner-brightgreen">
           <img src="https://img.shields.io/badge/type-general-red">
+          <a href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_parcels_structure.ipynb" onclick="captureTutorialLink('tutorial_parcels_structure');"><img src="https://img.shields.io/static/v1?label=&message=GitHub&color=blue&logo=github"></a>
         </div>
       </div>
     </div>
@@ -305,6 +306,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card-footer">
           <img src="https://img.shields.io/badge/level-beginner-brightgreen">
           <img src="https://img.shields.io/badge/type-general-red">
+          <a href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/parcels_tutorial.ipynb" onclick="captureTutorialLink('parcels_tutorial');"><img src="https://img.shields.io/static/v1?label=&message=GitHub&color=blue&logo=github"></a>
         </div>
       </div>
     </div>
@@ -325,6 +327,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card-footer">
           <img src="https://img.shields.io/badge/level-beginner-brightgreen">
           <img src="https://img.shields.io/badge/type-output-1fba3f">
+          <a href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_output.ipynb" onclick="captureTutorialLink('tutorial_output');"><img src="https://img.shields.io/static/v1?label=&message=GitHub&color=blue&logo=github"></a>
         </div>
       </div>
     </div>
@@ -343,6 +346,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
           A tutorial to explain how to implement periodic (east-west or north-south) boundaries in Parcels
           <br>
           <img src="https://img.shields.io/badge/type-FieldSet-c3b100">
+          <a href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_periodic_boundaries.ipynb" onclick="captureTutorialLink('tutorial_periodic_boundaries');"><img src="https://img.shields.io/static/v1?label=&message=GitHub&color=blue&logo=github"></a>
         </div>
       </a>
     </div>
@@ -356,6 +360,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
           A tutorial on the different interpolation methods available in Parcels
           <br>
           <img src="https://img.shields.io/badge/type-FieldSet-c3b100">
+          <a href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_interpolation.ipynb" onclick="captureTutorialLink('tutorial_interpolation');"><img src="https://img.shields.io/static/v1?label=&message=GitHub&color=blue&logo=github"></a>
         </div>
       </a>
     </div>
@@ -369,6 +374,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
           A tutorial on how Parcels automatically converts the units of velocity and diffusion fields from meters to degrees
           <br>
           <img src="https://img.shields.io/badge/type-FieldSet-c3b100">
+          <a href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_unitconverters.ipynb" onclick="captureTutorialLink('tutorial_unitconverters');"><img src="https://img.shields.io/static/v1?label=&message=GitHub&color=blue&logo=github"></a>
         </div>
       </a>
     </div>
@@ -382,6 +388,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
           A tutorial on how to create <code class="language-python">FieldSets</code> from NetCDF files with Calendars that can't be parsed by <code class="language-python">xarray</code>
           <br>
           <img src="https://img.shields.io/badge/type-FieldSet-c3b100">
+          <a href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_timestamps.ipynb" onclick="captureTutorialLink('tutorial_timestamps');"><img src="https://img.shields.io/static/v1?label=&message=GitHub&color=blue&logo=github"></a>
         </div>
       </a>
     </div>
@@ -395,6 +402,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
           A notebook with background on the different types of grid indexing
           <br>
           <img src="https://img.shields.io/badge/type-FieldSet-c3b100">
+          <a href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/documentation_indexing.ipynb" onclick="captureTutorialLink('documentation_indexing');"><img src="https://img.shields.io/static/v1?label=&message=GitHub&color=blue&logo=github"></a>
         </div>
       </a>
     </div>
@@ -408,6 +416,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
           A tutorial to explain how to use Parcels with hydrodynamic models that use curvilinear grids, such as NEMO
           <br>
           <img src="https://img.shields.io/badge/type-FieldSet-c3b100">
+          <a href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_nemo_curvilinear.ipynb" onclick="captureTutorialLink('tutorial_nemo_curvilinear');"><img src="https://img.shields.io/static/v1?label=&message=GitHub&color=blue&logo=github"></a>
         </div>
       </a>
     </div>
@@ -421,6 +430,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
           A tutorial to create a <code class="language-python">FieldSet</code> for three-dimensional NEMO data and other C-grids
           <br>
           <img src="https://img.shields.io/badge/type-FieldSet-c3b100">
+          <a href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_nemo_3D.ipynb" onclick="captureTutorialLink('tutorial_nemo_3D');"><img src="https://img.shields.io/static/v1?label=&message=GitHub&color=blue&logo=github"></a>
         </div>
       </a>
     </div>
@@ -434,6 +444,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
           A tutorial on how to combine different Fields for advection
           <br>
           <img src="https://img.shields.io/badge/type-FieldSet-c3b100">
+          <a href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_SummedFields.ipynb" onclick="captureTutorialLink('tutorial_SummedFields');"><img src="https://img.shields.io/static/v1?label=&message=GitHub&color=blue&logo=github"></a>
         </div>
       </a>
     </div>
@@ -447,6 +458,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
           A tutorial on how to use Fields with (multiple) nested domains
           <br>
           <img src="https://img.shields.io/badge/type-FieldSet-c3b100">
+          <a href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_NestedFields.ipynb" onclick="captureTutorialLink('tutorial_NestedFields');"><img src="https://img.shields.io/static/v1?label=&message=GitHub&color=blue&logo=github"></a>
         </div>
       </a>
     </div>
@@ -465,6 +477,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
           A tutorial that explains the different types of particles that come with Parcels
           <br>
           <img src="https://img.shields.io/badge/type-ParticleSet-11aed5">
+          <a href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_jit_vs_scipy.ipynb" onclick="captureTutorialLink('tutorial_jit_vs_scipy');"><img src="https://img.shields.io/static/v1?label=&message=GitHub&color=blue&logo=github"></a>
         </div>
       </a>
     </div>
@@ -478,6 +491,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
           A tutorial on how to release particles after the start of a run
           <br>
           <img src="https://img.shields.io/badge/type-ParticleSet-11aed5">
+          <a href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_delaystart.ipynb" onclick="captureTutorialLink('tutorial_delaystart');"><img src="https://img.shields.io/static/v1?label=&message=GitHub&color=blue&logo=github"></a>
         </div>
       </a>
     </div>
@@ -497,6 +511,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
           <br>
           <img src="https://img.shields.io/badge/type-kernels-aa11d5">
           <img src="https://img.shields.io/badge/type-FieldSet-c3b100">
+          <a href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_diffusion.ipynb" onclick="captureTutorialLink('tutorial_diffusion');"><img src="https://img.shields.io/static/v1?label=&message=GitHub&color=blue&logo=github"></a>
         </div>
       </a>
     </div>
@@ -511,6 +526,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
           <br>
           <img src="https://img.shields.io/badge/type-kernels-aa11d5">
           <img src="https://img.shields.io/badge/type-ParticleSet-11aed5">
+          <a href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_sampling.ipynb" onclick="captureTutorialLink('tutorial_sampling');"><img src="https://img.shields.io/static/v1?label=&message=GitHub&color=blue&logo=github"></a>
         </div>
       </a>
     </div>
@@ -525,6 +541,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
           <br>
           <img src="https://img.shields.io/badge/type-kernels-aa11d5">
           <img src="https://img.shields.io/badge/type-ParticleSet-11aed5">
+          <a href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_Argofloats.ipynb" onclick="captureTutorialLink('tutorial_Argofloats');"><img src="https://img.shields.io/static/v1?label=&message=GitHub&color=blue&logo=github"></a>
         </div>
       </a>
     </div>
@@ -541,6 +558,8 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             Parallelisation documentation
           </h5>
           A notebook with background on the parallelisation approach
+          <br>
+          <a href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/documentation_MPI.ipynb" onclick="captureTutorialLink('documentation_MPI');"><img src="https://img.shields.io/static/v1?label=&message=GitHub&color=blue&logo=github"></a>
         </div>
       </a>
     </div>
@@ -554,6 +573,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
           A notebook on how particles may end up stuck on land.
           <br>
           <img src="https://img.shields.io/badge/type-general-red">
+          <a href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/documentation_stuck_particles.ipynb" onclick="captureTutorialLink('documentation_stuck');"><img src="https://img.shields.io/static/v1?label=&message=GitHub&color=blue&logo=github"></a>
         </div>
       </a>
     </div>
@@ -567,6 +587,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
           A tutorial on how to quickly plot particle trajectories
           <br>
           <img src="https://img.shields.io/badge/type-output-1fba3f">
+          <a href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_plotting.ipynb" onclick="captureTutorialLink('tutorial_plotting');"><img src="https://img.shields.io/static/v1?label=&message=GitHub&color=blue&logo=github"></a>
         </div>
       </a>
     </div>


### PR DESCRIPTION
Due to [failures in the GitHub API](https://github.com/jupyter/nbviewer/issues/912), the nbviewer cannot always find the notebook. To circumvent this I added some shields with links to the actual notebook file on github. Sometimes these pages also have difficulties loading the notebook, but refreshing usually helps there. Does anyone have alternative ideas for this?