### PR TITLE
Fix nbviewer links

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -278,7 +278,7 @@ fset = FieldSet.from_netcdf(filenames, variables, dimensions)</code></pre>
             Adding the particle to the sampling can dramatically speed up
             simulations in Scipy-mode on Curvilinear Grids, see als the
             <a
-              href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_jit_vs_scipy.ipynb"
+              href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_jit_vs_scipy.ipynb"
               >JIT-vs_Scipy tutorial</a
             >.
           </li>

--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@
                 ><br />
                 See
                 <a
-                  href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/documentation_homepage_animation.ipynb"
+                  href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/documentation_homepage_animation.ipynb"
                   style="color: white"
                   >this tutorial
                   <i class="fa fa-external-link fa-1x" style="color: white"></i
@@ -602,7 +602,7 @@ pip install git+https://github.com/OceanParcels/parcels.git@master
       Parcels uses MPI for parallel execution, but this only works on linux and
       macOS. To install it, follow the steps below and see
       <a
-        href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/documentation_MPI.ipynb"
+        href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/documentation_MPI.ipynb"
         >here for further documentation</a
       >
       <p></p>
@@ -676,7 +676,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             <h4 class="card-header">
               <a
                 class="tutorialLink"
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_parcels_structure.ipynb"
+                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_parcels_structure.ipynb"
                 onclick="captureTutorialLink('tutorial_parcels_structure');"
               >
                 General Parcels structure
@@ -716,7 +716,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             <h4 class="card-header">
               <a
                 class="tutorialLink"
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/parcels_tutorial.ipynb"
+                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/parcels_tutorial.ipynb"
                 onclick="captureTutorialLink('parcels_tutorial');"
               >
                 Simple Parcels tutorial
@@ -756,7 +756,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             <h4 class="card-header">
               <a
                 class="tutorialLink"
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_output.ipynb"
+                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_output.ipynb"
                 onclick="captureTutorialLink('tutorial_output');"
               >
                 Output tutorial
@@ -764,7 +764,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             </h4>
             <div class="card-body">
               <a
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_output.ipynb"
+                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_output.ipynb"
                 onclick="captureTutorialLink('tutorial_output');"
                 ><img
                   alt=""
@@ -797,7 +797,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_periodic_boundaries.ipynb"
+            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_periodic_boundaries.ipynb"
             onclick="captureTutorialLink('tutorial_periodic_boundaries');"
           >
             <div class="card-header" role="tab">
@@ -818,7 +818,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_interpolation.ipynb"
+            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_interpolation.ipynb"
             onclick="captureTutorialLink('tutorial_interpolation');"
           >
             <div class="card-header" role="tab">
@@ -839,7 +839,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_unitconverters.ipynb"
+            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_unitconverters.ipynb"
             onclick="captureTutorialLink('tutorial_unitconverters');"
           >
             <div class="card-header" role="tab">
@@ -860,7 +860,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_timestamps.ipynb"
+            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_timestamps.ipynb"
             onclick="captureTutorialLink('tutorial_timestamps');"
           >
             <div class="card-header" role="tab">
@@ -883,7 +883,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/documentation_indexing.ipynb"
+            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/documentation_indexing.ipynb"
             onclick="captureTutorialLink('documentation_indexing');"
           >
             <div class="card-header" role="tab">
@@ -903,7 +903,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_nemo_curvilinear.ipynb"
+            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_nemo_curvilinear.ipynb"
             onclick="captureTutorialLink('tutorial_nemo_curvilinear');"
           >
             <div class="card-header" role="tab">
@@ -924,7 +924,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_nemo_3D.ipynb"
+            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_nemo_3D.ipynb"
             onclick="captureTutorialLink('tutorial_nemo_3D');"
           >
             <div class="card-header" role="tab">
@@ -946,7 +946,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_SummedFields.ipynb"
+            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_SummedFields.ipynb"
             onclick="captureTutorialLink('tutorial_SummedFields');"
           >
             <div class="card-header" role="tab">
@@ -966,7 +966,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_NestedFields.ipynb"
+            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_NestedFields.ipynb"
             onclick="captureTutorialLink('tutorial_NestedFields');"
           >
             <div class="card-header" role="tab">
@@ -986,7 +986,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_timevaryingdepthdimensions.ipynb"
+            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_timevaryingdepthdimensions.ipynb"
             onclick="captureTutorialLink('tutorial_TimevaryingSigma');"
           >
             <div class="card-header" role="tab">
@@ -1012,7 +1012,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_jit_vs_scipy.ipynb"
+            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_jit_vs_scipy.ipynb"
             onclick="captureTutorialLink('tutorial_jit_vs_scipy');"
           >
             <div class="card-header" role="tab">
@@ -1033,7 +1033,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_delaystart.ipynb"
+            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_delaystart.ipynb"
             onclick="captureTutorialLink('tutorial_delaystart');"
           >
             <div class="card-header" role="tab">
@@ -1060,7 +1060,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_diffusion.ipynb"
+            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_diffusion.ipynb"
             onclick="captureTutorialLink('tutorial_diffusion');"
           >
             <div class="card-header" role="tab">
@@ -1083,7 +1083,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_sampling.ipynb?flush_cache=true"
+            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_sampling.ipynb?flush_cache=true"
             onclick="captureTutorialLink('tutorial_sampling');"
           >
             <div class="card-header" role="tab">
@@ -1104,7 +1104,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_particle_field_interaction.ipynb?flush_cache=true"
+            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_particle_field_interaction.ipynb?flush_cache=true"
             onclick="captureTutorialLink('tutorial_particle_field_interaction');"
           >
             <div class="card-header" role="tab">
@@ -1126,7 +1126,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_interaction.ipynb?flush_cache=true"
+            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_interaction.ipynb?flush_cache=true"
             onclick="captureTutorialLink('tutorial_interaction');"
           >
             <div class="card-header" role="tab">
@@ -1148,7 +1148,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_Argofloats.ipynb"
+            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_Argofloats.ipynb"
             onclick="captureTutorialLink('tutorial_Argofloats');"
           >
             <div class="card-header" role="tab">
@@ -1175,7 +1175,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/documentation_MPI.ipynb"
+            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/documentation_MPI.ipynb"
             onclick="captureTutorialLink('documentation_MPI');"
           >
             <div class="card-header" role="tab">
@@ -1194,7 +1194,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/documentation_stuck_particles.ipynb"
+            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/documentation_stuck_particles.ipynb"
             onclick="captureTutorialLink('documentation_stuck');"
           >
             <div class="card-header" role="tab">
@@ -1214,7 +1214,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/documentation_unstuck_Agrid.ipynb"
+            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/documentation_unstuck_Agrid.ipynb"
             onclick="captureTutorialLink('documentation_unstuck_Agrid');"
           >
             <div class="card-header" role="tab">
@@ -1235,7 +1235,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_plotting.ipynb"
+            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_plotting.ipynb"
             onclick="captureTutorialLink('tutorial_plotting');"
           >
             <div class="card-header" role="tab">
@@ -1284,7 +1284,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               <code class="language-python">Euler-Maruyama</code> schemes. See
               the
               <a
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_diffusion.ipynb"
+                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_diffusion.ipynb"
                 >diffusion tutorial</a
               >.</small
             >
@@ -1327,7 +1327,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               >
               and
               <a
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_NestedFields.ipynb"
+                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_NestedFields.ipynb"
                 >NestedFields</a
               >
               tutorials</small
@@ -1394,7 +1394,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               <a href="#parallel_install">here for installation instructions</a>
               and
               <a
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/documentation_MPI.ipynb"
+                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/documentation_MPI.ipynb"
                 >here for further documentation</a
               ></small
             >
@@ -1407,7 +1407,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               >z-level, sigma-level (terrain-following), or rho-level
               (density-following). The latter either in time-fixed or
               <a
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_timevaryingdepthdimensions.ipynb"
+                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_timevaryingdepthdimensions.ipynb"
                 >time-varying coordinates</a
               ></small
             >
@@ -1419,7 +1419,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             <small class="text-muted"
               >Support for rudimentary particle-particle interaction, see
               <a
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_interaction.ipynb?flush_cache=true"
+                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_interaction.ipynb?flush_cache=true"
                 >this tutorial</a
               >
             </small>
@@ -1431,12 +1431,12 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             <small class="text-muted"
               >Support for particles that change a Field (in
               <a
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_jit_vs_scipy.ipynb"
+                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_jit_vs_scipy.ipynb"
                 >Scipy-mode</a
               >
               only), see
               <a
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_particle_field_interaction.ipynb?flush_cache=true"
+                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_particle_field_interaction.ipynb?flush_cache=true"
                 >this tutorial</a
               >
             </small>
@@ -1448,7 +1448,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             <small class="text-muted"
               >Using
               <a
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_analyticaladvection.ipynb"
+                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/tutorial_analyticaladvection.ipynb"
                 >inbuilt kernel</a
               >
               for
@@ -1462,7 +1462,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             <small class="text-muted"
               >By for example implementing
               <a
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/documentation_unstuck_Agrid.ipynb"
+                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/documentation_unstuck_Agrid.ipynb"
                 >free- and partial-slip boundary conditions</a
               ></small
             >
@@ -1681,10 +1681,10 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
           <div class="card">
             <div class="card-header" role="tab">
               <h5 class="mb-0">
-                Lagrangian Coherent Structures in the Mediterranean Sea: 
+                Lagrangian Coherent Structures in the Mediterranean Sea:
                 Seasonality and Basin Regimes
               </h5>
-              Antivachis, D, V Vervatis, S Sofianos (2023), 
+              Antivachis, D, V Vervatis, S Sofianos (2023),
               <i>Progress in Oceanography</i>, <i>in press</i>.<br />
               <a
                 aria-expanded="true"
@@ -1693,7 +1693,9 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
                 href="#antivachis2023"
                 >[ Expand abstract ]</a
               >
-              <a class="card-link" href="https://doi.org/10.1016/j.pocean.2023.103051"
+              <a
+                class="card-link"
+                href="https://doi.org/10.1016/j.pocean.2023.103051"
                 ><i class="fa fa-external-link fa-1x"></i> [ Link to article
                 ]</a
               >
@@ -1701,25 +1703,26 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             </div>
             <div class="collapse" id="antivachis2023" role="tabpanel">
               <div class="card-body">
-                The dynamics of fluid flows give rise to robust, persistent circulation 
-                features that underpin the flow and exert strong control over the 
-                advection of water masses, either enhancing it or supressing it, 
-                collectively known as lagrangian coherent structures. 
-                Lagrangian approaches and metrics have been shown to be better 
-                suited than eulerian ones at locating and delineating such 
-                structures and capturing the effect they have on the formation 
-                and dispersion of water masses, particularly at the smaller scales. 
-                In this paper, we use the framework of lagrangian coherent structures 
-                to analyse the ocean velocity fields over a climatological year 
-                obtained from a high-resolution eddy-resolving model in order to 
-                investigate the lagrangian regimes that affect the motion, separation 
-                and mixing of water masses in the Mediterranean Sea. The lagrangian 
-                regimes that develop in each sub-basin over the course of the year 
-                are characterised and regions of persistent lagrangian activity and 
-                coherent structure formation and presence are identified. A 
-                quantitative picture of the seasonal variability of the lagrangian 
-                coherent structure-induced horizontal mixing and vortex formation 
-                is obtained.
+                The dynamics of fluid flows give rise to robust, persistent
+                circulation features that underpin the flow and exert strong
+                control over the advection of water masses, either enhancing it
+                or supressing it, collectively known as lagrangian coherent
+                structures. Lagrangian approaches and metrics have been shown to
+                be better suited than eulerian ones at locating and delineating
+                such structures and capturing the effect they have on the
+                formation and dispersion of water masses, particularly at the
+                smaller scales. In this paper, we use the framework of
+                lagrangian coherent structures to analyse the ocean velocity
+                fields over a climatological year obtained from a
+                high-resolution eddy-resolving model in order to investigate the
+                lagrangian regimes that affect the motion, separation and mixing
+                of water masses in the Mediterranean Sea. The lagrangian regimes
+                that develop in each sub-basin over the course of the year are
+                characterised and regions of persistent lagrangian activity and
+                coherent structure formation and presence are identified. A
+                quantitative picture of the seasonal variability of the
+                lagrangian coherent structure-induced horizontal mixing and
+                vortex formation is obtained.
               </div>
             </div>
           </div>


### PR DESCRIPTION
Merging https://github.com/OceanParcels/parcels/pull/1355 will break all notebook links due to notebook relocation.

This PR changes
```diff
- https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/...
+ https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/docs/examples/...
```
Merge alongside https://github.com/OceanParcels/parcels/pull/1355