### PR TITLE
Changing the links to the tutorials on docs.oceanparcels.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@
                 ><br />
                 See
                 <a
-                  href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/documentation_homepage_animation.ipynb"
+                  href="https://docs.oceanparcels.org/en/latest/examples/documentation_homepage_animation.html"
                   style="color: white"
                   >this tutorial
                   <i class="fa fa-external-link fa-1x" style="color: white"></i
@@ -602,7 +602,7 @@ pip install git+https://github.com/OceanParcels/parcels.git@master
       Parcels uses MPI for parallel execution, but this only works on linux and
       macOS. To install it, follow the steps below and see
       <a
-        href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/documentation_MPI.ipynb"
+        href="https://docs.oceanparcels.org/en/latest/examples/documentation_MPI.html"
         >here for further documentation</a
       >
       <p></p>
@@ -676,7 +676,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             <h4 class="card-header">
               <a
                 class="tutorialLink"
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_parcels_structure.ipynb"
+                href="https://docs.oceanparcels.org/en/latest/examples/tutorial_parcels_structure.html"
                 onclick="captureTutorialLink('tutorial_parcels_structure');"
               >
                 General Parcels structure
@@ -684,7 +684,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             </h4>
             <div class="card-body">
               <a
-                href="http://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_parcels_structure.ipynb"
+                href="https://docs.oceanparcels.org/en/latest/examples/tutorial_parcels_structure.html"
                 onclick="captureTutorialLink('tutorial_parcels_structure');"
                 ><img
                   alt=""
@@ -703,7 +703,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               />
               <img src="https://img.shields.io/badge/type-general-red" />
               <a
-                href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_parcels_structure.ipynb"
+                href="https://github.com/OceanParcels/parcels/tree/master/docs/examples/tutorial_parcels_structure.ipynb"
                 onclick="captureTutorialLink('tutorial_parcels_structure');"
                 ><img
                   src="https://img.shields.io/static/v1?label=&amp;message=GitHub&amp;color=blue&amp;logo=github"
@@ -716,7 +716,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             <h4 class="card-header">
               <a
                 class="tutorialLink"
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/parcels_tutorial.ipynb"
+                href="https://docs.oceanparcels.org/en/latest/examples/parcels_tutorial.html"
                 onclick="captureTutorialLink('parcels_tutorial');"
               >
                 Simple Parcels tutorial
@@ -724,7 +724,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             </h4>
             <div class="card-body">
               <a
-                href="http://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/parcels_tutorial.ipynb"
+                href="https://docs.oceanparcels.org/en/latest/examples/parcels_tutorial.html"
                 onclick="captureTutorialLink('parcels_tutorial');"
                 ><img
                   alt=""
@@ -743,7 +743,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               />
               <img src="https://img.shields.io/badge/type-general-red" />
               <a
-                href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/parcels_tutorial.ipynb"
+                href="https://github.com/OceanParcels/parcels/tree/master/docs/examples/parcels_tutorial.ipynb"
                 onclick="captureTutorialLink('parcels_tutorial');"
                 ><img
                   src="https://img.shields.io/static/v1?label=&amp;message=GitHub&amp;color=blue&amp;logo=github"
@@ -756,7 +756,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             <h4 class="card-header">
               <a
                 class="tutorialLink"
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_output.ipynb"
+                href="https://docs.oceanparcels.org/en/latest/examples/tutorial_output.html"
                 onclick="captureTutorialLink('tutorial_output');"
               >
                 Output tutorial
@@ -764,7 +764,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             </h4>
             <div class="card-body">
               <a
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_output.ipynb"
+                href="https://docs.oceanparcels.org/en/latest/examples/tutorial_output.html"
                 onclick="captureTutorialLink('tutorial_output');"
                 ><img
                   alt=""
@@ -781,7 +781,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               />
               <img src="https://img.shields.io/badge/type-output-1fba3f" />
               <a
-                href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_output.ipynb"
+                href="https://github.com/OceanParcels/parcels/tree/master/docs/examples/tutorial_output.ipynb"
                 onclick="captureTutorialLink('tutorial_output');"
                 ><img
                   src="https://img.shields.io/static/v1?label=&amp;message=GitHub&amp;color=blue&amp;logo=github"
@@ -797,7 +797,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_periodic_boundaries.ipynb"
+            href="https://docs.oceanparcels.org/en/latest/examples/tutorial_periodic_boundaries.html"
             onclick="captureTutorialLink('tutorial_periodic_boundaries');"
           >
             <div class="card-header" role="tab">
@@ -807,7 +807,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               <br />
               <img src="https://img.shields.io/badge/type-FieldSet-c3b100" />
               <a
-                href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_periodic_boundaries.ipynb"
+                href="https://github.com/OceanParcels/parcels/tree/master/docs/examples/tutorial_periodic_boundaries.ipynb"
                 onclick="captureTutorialLink('tutorial_periodic_boundaries');"
                 ><img
                   src="https://img.shields.io/static/v1?label=&amp;message=GitHub&amp;color=blue&amp;logo=github"
@@ -818,7 +818,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_interpolation.ipynb"
+            href="https://docs.oceanparcels.org/en/latest/examples/tutorial_interpolation.html"
             onclick="captureTutorialLink('tutorial_interpolation');"
           >
             <div class="card-header" role="tab">
@@ -828,7 +828,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               <br />
               <img src="https://img.shields.io/badge/type-FieldSet-c3b100" />
               <a
-                href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_interpolation.ipynb"
+                href="https://github.com/OceanParcels/parcels/tree/master/docs/examples/tutorial_interpolation.ipynb"
                 onclick="captureTutorialLink('tutorial_interpolation');"
                 ><img
                   src="https://img.shields.io/static/v1?label=&amp;message=GitHub&amp;color=blue&amp;logo=github"
@@ -839,7 +839,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_unitconverters.ipynb"
+            href="https://docs.oceanparcels.org/en/latest/examples/tutorial_unitconverters.html"
             onclick="captureTutorialLink('tutorial_unitconverters');"
           >
             <div class="card-header" role="tab">
@@ -849,7 +849,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               <br />
               <img src="https://img.shields.io/badge/type-FieldSet-c3b100" />
               <a
-                href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_unitconverters.ipynb"
+                href="https://github.com/OceanParcels/parcels/tree/master/docs/examples/tutorial_unitconverters.ipynb"
                 onclick="captureTutorialLink('tutorial_unitconverters');"
                 ><img
                   src="https://img.shields.io/static/v1?label=&amp;message=GitHub&amp;color=blue&amp;logo=github"
@@ -860,7 +860,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_timestamps.ipynb"
+            href="https://docs.oceanparcels.org/en/latest/examples/tutorial_timestamps.html"
             onclick="captureTutorialLink('tutorial_timestamps');"
           >
             <div class="card-header" role="tab">
@@ -872,7 +872,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               <br />
               <img src="https://img.shields.io/badge/type-FieldSet-c3b100" />
               <a
-                href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_timestamps.ipynb"
+                href="https://github.com/OceanParcels/parcels/tree/master/docs/examples/tutorial_timestamps.ipynb"
                 onclick="captureTutorialLink('tutorial_timestamps');"
                 ><img
                   src="https://img.shields.io/static/v1?label=&amp;message=GitHub&amp;color=blue&amp;logo=github"
@@ -883,7 +883,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/documentation_indexing.ipynb"
+            href="https://docs.oceanparcels.org/en/latest/examples/documentation_indexing.html"
             onclick="captureTutorialLink('documentation_indexing');"
           >
             <div class="card-header" role="tab">
@@ -892,7 +892,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               <br />
               <img src="https://img.shields.io/badge/type-FieldSet-c3b100" />
               <a
-                href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/documentation_indexing.ipynb"
+                href="https://github.com/OceanParcels/parcels/tree/master/docs/examples/documentation_indexing.ipynb"
                 onclick="captureTutorialLink('documentation_indexing');"
                 ><img
                   src="https://img.shields.io/static/v1?label=&amp;message=GitHub&amp;color=blue&amp;logo=github"
@@ -903,7 +903,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_nemo_curvilinear.ipynb"
+            href="https://docs.oceanparcels.org/en/latest/examples/tutorial_nemo_curvilinear.html"
             onclick="captureTutorialLink('tutorial_nemo_curvilinear');"
           >
             <div class="card-header" role="tab">
@@ -913,7 +913,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               <br />
               <img src="https://img.shields.io/badge/type-FieldSet-c3b100" />
               <a
-                href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_nemo_curvilinear.ipynb"
+                href="https://github.com/OceanParcels/parcels/tree/master/docs/examples/tutorial_nemo_curvilinear.ipynb"
                 onclick="captureTutorialLink('tutorial_nemo_curvilinear');"
                 ><img
                   src="https://img.shields.io/static/v1?label=&amp;message=GitHub&amp;color=blue&amp;logo=github"
@@ -924,7 +924,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_nemo_3D.ipynb"
+            href="https://docs.oceanparcels.org/en/latest/examples/tutorial_nemo_3D.html"
             onclick="captureTutorialLink('tutorial_nemo_3D');"
           >
             <div class="card-header" role="tab">
@@ -935,7 +935,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               <br />
               <img src="https://img.shields.io/badge/type-FieldSet-c3b100" />
               <a
-                href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_nemo_3D.ipynb"
+                href="https://github.com/OceanParcels/parcels/tree/master/docs/examples/tutorial_nemo_3D.ipynb"
                 onclick="captureTutorialLink('tutorial_nemo_3D');"
                 ><img
                   src="https://img.shields.io/static/v1?label=&amp;message=GitHub&amp;color=blue&amp;logo=github"
@@ -946,7 +946,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_SummedFields.ipynb"
+            href="https://docs.oceanparcels.org/en/latest/examples/tutorial_SummedFields.html"
             onclick="captureTutorialLink('tutorial_SummedFields');"
           >
             <div class="card-header" role="tab">
@@ -955,7 +955,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               <br />
               <img src="https://img.shields.io/badge/type-FieldSet-c3b100" />
               <a
-                href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_SummedFields.ipynb"
+                href="https://github.com/OceanParcels/parcels/tree/master/docs/examples/tutorial_SummedFields.ipynb"
                 onclick="captureTutorialLink('tutorial_SummedFields');"
                 ><img
                   src="https://img.shields.io/static/v1?label=&amp;message=GitHub&amp;color=blue&amp;logo=github"
@@ -966,7 +966,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_NestedFields.ipynb"
+            href="https://docs.oceanparcels.org/en/latest/examples/tutorial_NestedFields.html"
             onclick="captureTutorialLink('tutorial_NestedFields');"
           >
             <div class="card-header" role="tab">
@@ -975,7 +975,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               <br />
               <img src="https://img.shields.io/badge/type-FieldSet-c3b100" />
               <a
-                href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_NestedFields.ipynb"
+                href="https://github.com/OceanParcels/parcels/tree/master/docs/examples/tutorial_NestedFields.ipynb"
                 onclick="captureTutorialLink('tutorial_NestedFields');"
                 ><img
                   src="https://img.shields.io/static/v1?label=&amp;message=GitHub&amp;color=blue&amp;logo=github"
@@ -986,7 +986,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_timevaryingdepthdimensions.ipynb"
+            href="https://docs.oceanparcels.org/en/latest/examples/tutorial_timevaryingdepthdimensions.html"
             onclick="captureTutorialLink('tutorial_TimevaryingSigma');"
           >
             <div class="card-header" role="tab">
@@ -1012,7 +1012,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_jit_vs_scipy.ipynb"
+            href="https://docs.oceanparcels.org/en/latest/examples/tutorial_jit_vs_scipy.html"
             onclick="captureTutorialLink('tutorial_jit_vs_scipy');"
           >
             <div class="card-header" role="tab">
@@ -1022,7 +1022,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               <br />
               <img src="https://img.shields.io/badge/type-ParticleSet-11aed5" />
               <a
-                href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_jit_vs_scipy.ipynb"
+                href="https://github.com/OceanParcels/parcels/tree/master/docs/examples/tutorial_jit_vs_scipy.ipynb"
                 onclick="captureTutorialLink('tutorial_jit_vs_scipy');"
                 ><img
                   src="https://img.shields.io/static/v1?label=&amp;message=GitHub&amp;color=blue&amp;logo=github"
@@ -1033,7 +1033,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_delaystart.ipynb"
+            href="https://docs.oceanparcels.org/en/latest/examples/tutorial_delaystart.html"
             onclick="captureTutorialLink('tutorial_delaystart');"
           >
             <div class="card-header" role="tab">
@@ -1042,7 +1042,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               <br />
               <img src="https://img.shields.io/badge/type-ParticleSet-11aed5" />
               <a
-                href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_delaystart.ipynb"
+                href="https://github.com/OceanParcels/parcels/tree/master/docs/examples/tutorial_delaystart.ipynb"
                 onclick="captureTutorialLink('tutorial_delaystart');"
                 ><img
                   src="https://img.shields.io/static/v1?label=&amp;message=GitHub&amp;color=blue&amp;logo=github"
@@ -1060,7 +1060,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_diffusion.ipynb"
+            href="https://docs.oceanparcels.org/en/latest/examples/tutorial_diffusion.html"
             onclick="captureTutorialLink('tutorial_diffusion');"
           >
             <div class="card-header" role="tab">
@@ -1072,7 +1072,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               <img src="https://img.shields.io/badge/type-kernels-aa11d5" />
               <img src="https://img.shields.io/badge/type-FieldSet-c3b100" />
               <a
-                href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_diffusion.ipynb"
+                href="https://github.com/OceanParcels/parcels/tree/master/docs/examples/tutorial_diffusion.ipynb"
                 onclick="captureTutorialLink('tutorial_diffusion');"
                 ><img
                   src="https://img.shields.io/static/v1?label=&amp;message=GitHub&amp;color=blue&amp;logo=github"
@@ -1083,7 +1083,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_sampling.ipynb?flush_cache=true"
+            href="https://docs.oceanparcels.org/en/latest/examples/tutorial_sampling.html"
             onclick="captureTutorialLink('tutorial_sampling');"
           >
             <div class="card-header" role="tab">
@@ -1093,7 +1093,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               <img src="https://img.shields.io/badge/type-kernels-aa11d5" />
               <img src="https://img.shields.io/badge/type-ParticleSet-11aed5" />
               <a
-                href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_sampling.ipynb"
+                href="https://github.com/OceanParcels/parcels/tree/master/docs/examples/tutorial_sampling.ipynb"
                 onclick="captureTutorialLink('tutorial_sampling');"
                 ><img
                   src="https://img.shields.io/static/v1?label=&amp;message=GitHub&amp;color=blue&amp;logo=github"
@@ -1104,7 +1104,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_particle_field_interaction.ipynb?flush_cache=true"
+            href="https://docs.oceanparcels.org/en/latest/examples/tutorial_particle_field_interaction.html"
             onclick="captureTutorialLink('tutorial_particle_field_interaction');"
           >
             <div class="card-header" role="tab">
@@ -1126,7 +1126,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_interaction.ipynb?flush_cache=true"
+            href="https://docs.oceanparcels.org/en/latest/examples/tutorial_interaction.html"
             onclick="captureTutorialLink('tutorial_interaction');"
           >
             <div class="card-header" role="tab">
@@ -1148,7 +1148,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_Argofloats.ipynb"
+            href="https://docs.oceanparcels.org/en/latest/examples/tutorial_Argofloats.html"
             onclick="captureTutorialLink('tutorial_Argofloats');"
           >
             <div class="card-header" role="tab">
@@ -1159,7 +1159,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               <img src="https://img.shields.io/badge/type-kernels-aa11d5" />
               <img src="https://img.shields.io/badge/type-ParticleSet-11aed5" />
               <a
-                href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_Argofloats.ipynb"
+                href="https://github.com/OceanParcels/parcels/tree/master/docs/examples/tutorial_Argofloats.ipynb"
                 onclick="captureTutorialLink('tutorial_Argofloats');"
                 ><img
                   src="https://img.shields.io/static/v1?label=&amp;message=GitHub&amp;color=blue&amp;logo=github"
@@ -1175,7 +1175,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/documentation_MPI.ipynb"
+            href="https://docs.oceanparcels.org/en/latest/examples/documentation_MPI.html"
             onclick="captureTutorialLink('documentation_MPI');"
           >
             <div class="card-header" role="tab">
@@ -1183,7 +1183,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               A notebook with background on the parallelisation approach
               <br />
               <a
-                href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/documentation_MPI.ipynb"
+                href="https://github.com/OceanParcels/parcels/tree/master/docs/examples/documentation_MPI.ipynb"
                 onclick="captureTutorialLink('documentation_MPI');"
                 ><img
                   src="https://img.shields.io/static/v1?label=&amp;message=GitHub&amp;color=blue&amp;logo=github"
@@ -1194,7 +1194,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/documentation_stuck_particles.ipynb"
+            href="https://docs.oceanparcels.org/en/latest/examples/documentation_stuck_particles.html"
             onclick="captureTutorialLink('documentation_stuck');"
           >
             <div class="card-header" role="tab">
@@ -1203,7 +1203,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               <br />
               <img src="https://img.shields.io/badge/type-general-red" />
               <a
-                href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/documentation_stuck_particles.ipynb"
+                href="https://github.com/OceanParcels/parcels/tree/master/docs/examples/documentation_stuck_particles.ipynb"
                 onclick="captureTutorialLink('documentation_stuck');"
                 ><img
                   src="https://img.shields.io/static/v1?label=&amp;message=GitHub&amp;color=blue&amp;logo=github"
@@ -1214,7 +1214,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/documentation_unstuck_Agrid.ipynb"
+            href="https://docs.oceanparcels.org/en/latest/examples/documentation_unstuck_Agrid.html"
             onclick="captureTutorialLink('documentation_unstuck_Agrid');"
           >
             <div class="card-header" role="tab">
@@ -1224,7 +1224,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               <br />
               <img src="https://img.shields.io/badge/type-general-red" />
               <a
-                href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/documentation_unstuck_Agrid.ipynb"
+                href="https://github.com/OceanParcels/parcels/tree/master/docs/examples/documentation_unstuck_Agrid.ipynb"
                 onclick="captureTutorialLink('documentation_unstuck_Agrid');"
                 ><img
                   src="https://img.shields.io/static/v1?label=&amp;message=GitHub&amp;color=blue&amp;logo=github"
@@ -1235,7 +1235,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
         <div class="card">
           <a
             class="tutorialLink"
-            href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_plotting.ipynb"
+            href="https://docs.oceanparcels.org/en/latest/examples/tutorial_plotting.html"
             onclick="captureTutorialLink('tutorial_plotting');"
           >
             <div class="card-header" role="tab">
@@ -1244,7 +1244,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               <br />
               <img src="https://img.shields.io/badge/type-output-1fba3f" />
               <a
-                href="https://github.com/OceanParcels/parcels/tree/master/parcels/examples/tutorial_plotting.ipynb"
+                href="https://github.com/OceanParcels/parcels/tree/master/docs/examples/tutorial_plotting.ipynb"
                 onclick="captureTutorialLink('tutorial_plotting');"
                 ><img
                   src="https://img.shields.io/static/v1?label=&amp;message=GitHub&amp;color=blue&amp;logo=github"
@@ -1284,7 +1284,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               <code class="language-python">Euler-Maruyama</code> schemes. See
               the
               <a
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_diffusion.ipynb"
+                href="https://docs.oceanparcels.org/en/latest/examples/tutorial_diffusion.html"
                 >diffusion tutorial</a
               >.</small
             >
@@ -1296,7 +1296,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             <small class="text-muted"
               >See the
               <a
-                href="http://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/parcels_tutorial.ipynb#Adding-a-custom-behaviour-kernel"
+                href="https://docs.oceanparcels.org/en/latest/examples/parcels_tutorial.html#Adding-a-custom-behaviour-kernel"
                 >Adding-a-custom-behaviour-kernel</a
               >
               part of the Parcels tutorial</small
@@ -1309,7 +1309,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             <small class="text-muted"
               >See the
               <a
-                href="http://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/parcels_tutorial.ipynb#Sampling-a-Field-with-Particles"
+                href="https://docs.oceanparcels.org/en/latest/examples/parcels_tutorial.html#Sampling-a-Field-with-Particles"
                 >sampling a Field with Particles</a
               >
               part of the Parcels tutorial</small
@@ -1322,12 +1322,12 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             <small class="text-muted"
               >See the
               <a
-                href="http://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_SummedFields.ipynb"
+                href="https://docs.oceanparcels.org/en/latest/examples/tutorial_SummedFields.html"
                 >SummedFields</a
               >
               and
               <a
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_NestedFields.ipynb"
+                href="https://docs.oceanparcels.org/en/latest/examples/tutorial_NestedFields.html"
                 >NestedFields</a
               >
               tutorials</small
@@ -1340,7 +1340,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             <small class="text-muted">
               See the
               <a
-                href="http://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_delaystart.ipynb"
+                href="https://docs.oceanparcels.org/en/latest/examples/tutorial_delaystart.html"
                 >delayed start tutorial</a
               ></small
             >
@@ -1355,7 +1355,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             <small class="text-muted"
               >see the
               <a
-                href="http://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/parcels_tutorial.ipynb#Reading-in-data-from-arbritrary-NetCDF-files"
+                href="https://docs.oceanparcels.org/en/latest/examples/parcels_tutorial.html#Reading-in-data-from-arbritrary-NetCDF-files"
                 >reading in data from arbitrary NetCDF files</a
               >
               part of the Parcels tutorial</small
@@ -1376,7 +1376,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             <small class="text-muted"
               >Both on the fly and from zarr output files, see the
               <a
-                href="http://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_plotting.ipynb"
+                href="https://docs.oceanparcels.org/en/latest/examples/tutorial_plotting.html"
                 >plotting tutorial</a
               ></small
             >
@@ -1394,7 +1394,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               <a href="#parallel_install">here for installation instructions</a>
               and
               <a
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/documentation_MPI.ipynb"
+                href="https://docs.oceanparcels.org/en/latest/examples/documentation_MPI.html"
                 >here for further documentation</a
               ></small
             >
@@ -1407,7 +1407,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
               >z-level, sigma-level (terrain-following), or rho-level
               (density-following). The latter either in time-fixed or
               <a
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_timevaryingdepthdimensions.ipynb"
+                href="https://docs.oceanparcels.org/en/latest/examples/tutorial_timevaryingdepthdimensions.html"
                 >time-varying coordinates</a
               ></small
             >
@@ -1419,7 +1419,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             <small class="text-muted"
               >Support for rudimentary particle-particle interaction, see
               <a
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_interaction.ipynb?flush_cache=true"
+                href="https://docs.oceanparcels.org/en/latest/examples/tutorial_interaction.html"
                 >this tutorial</a
               >
             </small>
@@ -1431,12 +1431,12 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             <small class="text-muted"
               >Support for particles that change a Field (in
               <a
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_jit_vs_scipy.ipynb"
+                href="https://docs.oceanparcels.org/en/latest/examples/tutorial_jit_vs_scipy.html"
                 >Scipy-mode</a
               >
               only), see
               <a
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_particle_field_interaction.ipynb?flush_cache=true"
+                href="https://docs.oceanparcels.org/en/latest/examples/tutorial_particle_field_interaction.html"
                 >this tutorial</a
               >
             </small>
@@ -1448,7 +1448,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             <small class="text-muted"
               >Using
               <a
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/tutorial_analyticaladvection.ipynb"
+                href="https://docs.oceanparcels.org/en/latest/examples/tutorial_analyticaladvection.html"
                 >inbuilt kernel</a
               >
               for
@@ -1462,7 +1462,7 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             <small class="text-muted"
               >By for example implementing
               <a
-                href="https://nbviewer.jupyter.org/github/OceanParcels/parcels/blob/master/parcels/examples/documentation_unstuck_Agrid.ipynb"
+                href="https://docs.oceanparcels.org/en/latest/examples/documentation_unstuck_Agrid.html"
                 >free- and partial-slip boundary conditions</a
               ></small
             >
@@ -1681,10 +1681,10 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
           <div class="card">
             <div class="card-header" role="tab">
               <h5 class="mb-0">
-                Lagrangian Coherent Structures in the Mediterranean Sea: 
+                Lagrangian Coherent Structures in the Mediterranean Sea:
                 Seasonality and Basin Regimes
               </h5>
-              Antivachis, D, V Vervatis, S Sofianos (2023), 
+              Antivachis, D, V Vervatis, S Sofianos (2023),
               <i>Progress in Oceanography</i>, <i>in press</i>.<br />
               <a
                 aria-expanded="true"
@@ -1693,7 +1693,9 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
                 href="#antivachis2023"
                 >[ Expand abstract ]</a
               >
-              <a class="card-link" href="https://doi.org/10.1016/j.pocean.2023.103051"
+              <a
+                class="card-link"
+                href="https://doi.org/10.1016/j.pocean.2023.103051"
                 ><i class="fa fa-external-link fa-1x"></i> [ Link to article
                 ]</a
               >
@@ -1701,25 +1703,26 @@ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/Applications/Xcode.app/Contents//Develope
             </div>
             <div class="collapse" id="antivachis2023" role="tabpanel">
               <div class="card-body">
-                The dynamics of fluid flows give rise to robust, persistent circulation 
-                features that underpin the flow and exert strong control over the 
-                advection of water masses, either enhancing it or supressing it, 
-                collectively known as lagrangian coherent structures. 
-                Lagrangian approaches and metrics have been shown to be better 
-                suited than eulerian ones at locating and delineating such 
-                structures and capturing the effect they have on the formation 
-                and dispersion of water masses, particularly at the smaller scales. 
-                In this paper, we use the framework of lagrangian coherent structures 
-                to analyse the ocean velocity fields over a climatological year 
-                obtained from a high-resolution eddy-resolving model in order to 
-                investigate the lagrangian regimes that affect the motion, separation 
-                and mixing of water masses in the Mediterranean Sea. The lagrangian 
-                regimes that develop in each sub-basin over the course of the year 
-                are characterised and regions of persistent lagrangian activity and 
-                coherent structure formation and presence are identified. A 
-                quantitative picture of the seasonal variability of the lagrangian 
-                coherent structure-induced horizontal mixing and vortex formation 
-                is obtained.
+                The dynamics of fluid flows give rise to robust, persistent
+                circulation features that underpin the flow and exert strong
+                control over the advection of water masses, either enhancing it
+                or supressing it, collectively known as lagrangian coherent
+                structures. Lagrangian approaches and metrics have been shown to
+                be better suited than eulerian ones at locating and delineating
+                such structures and capturing the effect they have on the
+                formation and dispersion of water masses, particularly at the
+                smaller scales. In this paper, we use the framework of
+                lagrangian coherent structures to analyse the ocean velocity
+                fields over a climatological year obtained from a
+                high-resolution eddy-resolving model in order to investigate the
+                lagrangian regimes that affect the motion, separation and mixing
+                of water masses in the Mediterranean Sea. The lagrangian regimes
+                that develop in each sub-basin over the course of the year are
+                characterised and regions of persistent lagrangian activity and
+                coherent structure formation and presence are identified. A
+                quantitative picture of the seasonal variability of the
+                lagrangian coherent structure-induced horizontal mixing and
+                vortex formation is obtained.
               </div>
             </div>
           </div>

--- a/utrechtteam.html
+++ b/utrechtteam.html
@@ -205,7 +205,9 @@
             />
             <div class="card-body">
               <h4 class="card-title">Emma Daniëls</h4>
-              <h6 class="card-subtitle mb-2 text-muted">Postdoctoral researcher</h6>
+              <h6 class="card-subtitle mb-2 text-muted">
+                Postdoctoral researcher
+              </h6>
               <p class="card-text">
                 Emma develops a virtual ship learning experience.
               </p>


### PR DESCRIPTION
Quick fix for now, so that people can use the old layout of the oceanparcels.org landing page to still reach the tutorials.
