### PR TITLE
Linkchecking with Lychee GHA

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,61 @@
+name: Check URL Status
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 0 * * 0 # run at midnight every Sunday
+
+env:
+  LINK_TRACKING_ISSUE_NUMBER: 85
+
+permissions:
+  issues: write
+
+jobs:
+  check-urls:
+    env:
+      LYCHEE_REPORT_FILE: ./lychee/out.md
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.8.0
+
+      - name: Read Lychee report
+        if: env.lychee_exit_code != 0
+        id: readReport
+        run: |
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "FILE_CONTENT<<$EOF" >> $GITHUB_OUTPUT
+          echo "$(cat ${{ env.LYCHEE_REPORT_FILE }})" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
+      - run: echo "${{ steps.readReport.outputs.FILE_CONTENT }}"
+      - name: Update link tracking issue (update invalid links)
+        if: env.lychee_exit_code != 0
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: "update-issue"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ env.LINK_TRACKING_ISSUE_NUMBER }}
+          state: "open"
+          body: ${{ steps.readReport.outputs.FILE_CONTENT }}
+          update-mode: "replace"
+
+      - name: Update link tracking issue (no invalid links)
+        if: env.lychee_exit_code == 0
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: "update-issue"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ env.LINK_TRACKING_ISSUE_NUMBER }}
+          state: "closed"
+          body: "No invalid links found! 🤖"
+          update-mode: "replace"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: lychee-report
+          path: ${{ env.LYCHEE_REPORT_FILE }}


### PR DESCRIPTION
Implemented linkchecking, which produces the following errors.

| Status        | Count |
|---------------|-------|
| 🔍 Total      | 1368  |
| ✅ Successful | 1262  |
| ⏳ Timeouts   | 0     |
| 🔀 Redirected | 0     |
| 👻 Excluded   | 0     |
| ❓ Unknown    | 0     |
| 🚫 Errors     | 89    |

There are different approaches that we use to use to raise and then fix/ignore these errors.

Currently (i.e. the first commit in this PR), the CI workflow fails when a bad link is encountered and uploads the linkchecking report as an artifact to the GHA workflow run (which, of course, isn't ideal as it treats a link from a 3 year old presentation the same as a link on `index.html`.

I propose not failling the workflow, and instead dedicating an open issue to linkchecking. When the workflow runs, it updates the body of the issue with the updated report. That way, the issue can be periodically checked to see if any of the links in important pages are broken. This is a similar approach to the first example in the [Lychee readme](https://github.com/lycheeverse/lychee-action). _**Give me the go ahead, and I'll make the necessary edits and create the issue**_.

Let me know if you have any other suggestions on how to report links. I'll leave the triaging and fixing of the individual links to someone else if thats alright😄 