### PR TITLE
Disable `check-urls` on forks

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   check-urls:
+    if: ${{ !github.event.repository.fork }}
     env:
       LYCHEE_REPORT_FILE: ./lychee/out.md
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `check-urls` workflow (by design) doesn't work on forks. Disabling on forks to avoid workflow failures.