### PR TITLE
Update pre-commit prettier hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: "23.12.1"
     hooks:
       - id: black
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: https://github.com/rbubley/mirrors-prettier # Update mirror as official mirror is deprecated
+    rev: v3.3.3
     hooks:
       - id: prettier


### PR DESCRIPTION
Biome does not support the formatting of HTML files, resorting to a separate mirror of prettier which seems to be working better (the old one is deprecated and was creating a random cache file in my working directory).

Closes #98