### PR TITLE
Adding redirect page for oceanparcels.org/waddendrifters

### DIFF
--- a/public/waddendrifters.html
+++ b/public/waddendrifters.html
@@ -1,0 +1,7 @@
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0;url=/blog/waddendrifters" />
+    <title></title>
+  </head>
+ <body></body>
+</html>


### PR DESCRIPTION
This PR is an attempt to make oceanparcels.org/waddendrifters redirect to the new waddendrifters blog post. However, it now only works for `/waddendrifters.html`, but not for `/waddendrifters`. 

@VeckoTheGecko, would you know how to also make this work for the page without the `.html` extension?