### PR TITLE
Patch nextjs config - production asset hosting

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -18,9 +18,7 @@ const nextConfig = {
   images: {
     domains: ["raw.githubusercontent.com", "numpy.org", "dask.org", "chainer.org"],
   },
-  output: 'export',
-  basePath: process.env.NODE_ENV === 'production' ? '/oceanparcels_website' : '',
-  assetPrefix: process.env.NODE_ENV === 'production' ? '/oceanparcels_website/' : '',
+  output: 'export'
 }
 
 export default withMDX(nextConfig)


### PR DESCRIPTION
The nextJS config was broken before (it was a copied config not 100% suitable for our website. The paths shouldn't be different between dev and prod