### PR TITLE
Update VirtualShip link

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -13,7 +13,7 @@ export const Projects = [
     description:
       'VirtualShipParcels is a command-line simulator to plan and conduct a virtual research expedition.',
     repo: 'https://github.com/OceanParcels/virtualship',
-    homepage: 'https://virtualship.oceanparcels.org/en/latest/',
+    homepage: 'https://virtualship.oceanparcels.org',
     logo_light: '/projects/virtual_ship_logo.png',
     logo_dark: '/projects/virtual_ship_logo_dia.png',
   },


### PR DESCRIPTION
Now that VirtualShip has its own website, I'm updating the link here to point to that new website.

The docs are now hosted at https://virtualship.readthedocs.io/