### PR TITLE
Blog support for GFM, and update event schedule to table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "react-syntax-highlighter": "^15.5.0",
         "rehype-katex": "^7.0.1",
         "rehype-slug": "^6.0.0",
+        "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
         "swr": "^2.2.5"
       },
@@ -6457,6 +6458,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -6464,6 +6475,48 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -6484,6 +6537,107 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6818,6 +6972,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-math": {
@@ -8468,6 +8743,24 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-math": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
@@ -8525,6 +8818,21 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react-syntax-highlighter": "^15.5.0",
     "rehype-katex": "^7.0.1",
     "rehype-slug": "^6.0.0",
+    "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
     "swr": "^2.2.5"
   },

--- a/src/pages/blog/[id].js
+++ b/src/pages/blog/[id].js
@@ -17,6 +17,7 @@ import { ArrowBackIcon } from '@chakra-ui/icons'
 
 import { MDXRemote } from 'next-mdx-remote'
 import { serialize } from 'next-mdx-remote/serialize'
+import remarkGfm from 'remark-gfm'
 import rehypeSlug from 'rehype-slug'
 import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
@@ -125,7 +126,7 @@ export async function getStaticProps({ params }) {
   const { content, data } = matter(source)
   const mdxSource = await serialize(content, {
     mdxOptions: {
-      remarkPlugins: [remarkMath],
+      remarkPlugins: [remarkGfm, remarkMath],
       rehypePlugins: [rehypeSlug, rehypeKatex],
       format: 'mdx',
     },

--- a/src/posts/10year-event/index.md
+++ b/src/posts/10year-event/index.md
@@ -25,57 +25,50 @@ The event will end with a party on Friday evening 3 October 2025, in Utrecht. Th
 
 All times in the schedules below are in Central European Summer Time (GMT+2).
 
-- Wednesday 1 October
-  - 9:30 – 10:00 Central welcome to the workshops
-  - 10:00 – 12:00 Session 1a: How to get started with Parcels
-  - 10:00 – 12:00 Session 1b: The Parcels internals: how to get started with code-development
-  - 12:00 – 13:30 Lunch break
-  - 13:30 – 15:00 Session 2: Making your own custom kernels
-  - 15:00 – 15:30 Tea break
-  - 15:30 – 17:00 Session 3: Lagrangian Diagnostics.
-
-- Thursday 2 October
-  - 9:30 – 10:00 Central recap of Day 1
-  - 10:00 – 12:00 Session 4: What is Parcels v4? And how to get ready for it?
-  - 12:00 – 13:30 Lunch break
-  - 13:30 – 15:00 Session 5: Particle visualisations
-  - 15:00 – 15:30 Tea break
-  - 15:30 – 16:00 Central wrap-up of the workshops
-
-- Friday 3 October
-  - 9:30 – 10:00 Opening – The past and future of Parcels | Erik van Sebille
-  - 10:00 – 10:10 The Role of Submesoscale Processes in the Decay of Agulhas Rings | Leon-Cornelius Mock
-  - 10:10 – 10:20 Detecting Salinity Fronts from Satellite Observations using a Lagrangian reconstruction method | Vincent Combes (online)
-  - 10:20 – 10:30 Role of Mesoscale Activity for Freshwater Pathways from the Amazon River Plume to the Atlantic Ocean | Daniel Andres Lizarbe Barreto
-  - 10:30 – 11:00 Coffee break
-  - 11:00 – 11:10 Tracking the Iceland Scotland Overflow South of Iceland and Spreading of Deep Waters by Submesoscale Processes | Angel Ruiz-Angulo
-  - 11:10 – 11:20 Investigating the generation of thermohaline variability in the Southern Ocean using Lagrangian methods | Maya Jakes
-    (online)
-  - 11:20 – 11:30 Representing ingestion and egestion of microplastic particles by zooplankton in PlasticParcels: development of a new kernel and preliminary results | Gaia Buccino
-  - 11:30 – 11:40 Seasonal effects of hydrodynamics and biofouling on the vertical transport of microplastics in the Vietnam coastal region, South China Sea | Caiyuan Cai
-    (online)
-  - 11:40 – 11:50 Tracking Floating Microplastics Pathways to the Kara Sea with OceanParcels | Anfisa Berezina
-  - 11:50 – 12:00 A multigrid approach with high coastal resolution for the numerical modelling of the dispersion and accumulation of floating marine litter in the coastal area of Barcelona | Ivan Hernandez (online)
-  - 12:00 – 12:10 The role of windage, currents and Stokes drift on the distribution of plastic litter released from the Indian rivers | Vasimilla Suneel (online)
-  - 12:10 – 12:20 Floating macro-plastics retention in Baltic semi-enclosed coastal systems: A model study under different wind conditions | Bruna De Ramos
-  - 12:20 – 13:30 Lunch
-  - 13:30 – 13:40 Larval pathways of Aristeus antennatus revealed by Lagrangian dynamics and network theory | Ignacio Martínez Caballero
-  - 13:40 – 13:50 Individual-Based Lagrangian Modelling of Ecklonia maxima Dispersal Along the South African Coast | Ross Coppin
-  - 13:50 – 14:00 Eukaryotic phytoplankton are sustained by eddies and lateral mixing in the open ocean | Alexandra Jones-Kellett
-  - 14:00 – 14:10 Particulate organic carbon export in the Amazon River Plume | Danilo Augusto Silva
-  - 14:10 – 14:20 Modelling the spatial bound of an eDNA signal in the marine environment - the effect of oceanographic conditions | Tiago Silva
-  - 14:20 – 14:30 Larval dispersion and connectivity in the south-central Tyrrhenian Sea: a Lagrangian modeling approach using OceanParcels | Gianluca Liguori
-  - 14:30 – 14:40 Towards Operational Readiness: A multi-model forcing system for oil spill monitoring in the Mediterranean Sea | Beatrice Maddalena Scotto
-  - 14:40 – 14:50 Optimizing Big Data Preprocessing Through Prompt Engineering: Toward a New Paradigm of Foundation Model Pipelines | Arin Dewangan
-  - 14:50 – 15:30 Tea break
-  - 15:30 – 15:40 Surface Dispersion of Particles Released in the Port of Genoa: A Scenario-Based Lagrangian Analysis | Mattia Scovenna
-  - 15:40 – 15:50 Cross-disciplinary applications of particle tracking in the Greater Agulhas System | Michael Hart-Davis (online)
-  - 15:50 – 16:00 VirtualShip for simulating in-class oceanographic fieldwork anywhere in the global ocean | Jamie Atkins
-  - 16:00 – 16:10 Safe seas for manatees: Identifying Optimal Release Windows Using Ocean Reanalysis Simulations | Iury Simoes-Sousa (online)
-  - 16:10 – 17:00 Discussion, reflection and wrap-up | All attending
-
-- Friday evening 3 October
-  - Party (in Utrecht)
+| Date      | Time        | Title                                                                                                                                                                                                  |
+| --------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Wed 1 Oct | 9:30–10:00  | Central welcome to the workshops                                                                                                                                                                       |
+|           | 10:00–12:00 | Session 1a: How to get started with Parcels                                                                                                                                                            |
+|           | 10:00–12:00 | Session 1b: The Parcels internals: how to get started with code-development                                                                                                                            |
+|           | 12:00–13:30 | Lunch break                                                                                                                                                                                            |
+|           | 13:30–15:00 | Session 2: Making your own custom kernels                                                                                                                                                              |
+|           | 15:00–15:30 | Tea break                                                                                                                                                                                              |
+|           | 15:30–17:00 | Session 3: Lagrangian Diagnostics                                                                                                                                                                      |
+| Thu 2 Oct | 9:30–10:00  | Central recap of Day 1                                                                                                                                                                                 |
+|           | 10:00–12:00 | Session 4: What is Parcels v4? And how to get ready for it?                                                                                                                                            |
+|           | 12:00–13:30 | Lunch break                                                                                                                                                                                            |
+|           | 13:30–15:00 | Session 5: Particle visualisations                                                                                                                                                                     |
+|           | 15:00–15:30 | Tea break                                                                                                                                                                                              |
+|           | 15:30–16:00 | Central wrap-up of the workshops                                                                                                                                                                       |
+| Fri 3 Oct | 9:30–10:00  | Opening – The past and future of Parcels \| Erik van Sebille                                                                                                                                           |
+|           | 10:00–10:10 | The Role of Submesoscale Processes in the Decay of Agulhas Rings \| Leon-Cornelius Mock                                                                                                                |
+|           | 10:10–10:20 | Detecting Salinity Fronts from Satellite Observations using a Lagrangian reconstruction method \| Vincent Combes (online)                                                                              |
+|           | 10:20–10:30 | Role of Mesoscale Activity for Freshwater Pathways from the Amazon River Plume to the Atlantic Ocean \| Daniel Andres Lizarbe Barreto                                                                  |
+|           | 10:30–11:00 | Coffee break                                                                                                                                                                                           |
+|           | 11:00–11:10 | Tracking the Iceland Scotland Overflow South of Iceland and Spreading of Deep Waters by Submesoscale Processes \| Angel Ruiz-Angulo                                                                    |
+|           | 11:10–11:20 | Investigating the generation of thermohaline variability in the Southern Ocean using Lagrangian methods \| Maya Jakes (online)                                                                         |
+|           | 11:20–11:30 | Representing ingestion and egestion of microplastic particles by zooplankton in PlasticParcels: development of a new kernel and preliminary results \| Gaia Buccino                                    |
+|           | 11:30–11:40 | Seasonal effects of hydrodynamics and biofouling on the vertical transport of microplastics in the Vietnam coastal region, South China Sea \| Caiyuan Cai (online)                                     |
+|           | 11:40–11:50 | Tracking Floating Microplastics Pathways to the Kara Sea with OceanParcels \| Anfisa Berezina                                                                                                          |
+|           | 11:50–12:00 | A multigrid approach with high coastal resolution for the numerical modelling of the dispersion and accumulation of floating marine litter in the coastal area of Barcelona \| Ivan Hernandez (online) |
+|           | 12:00–12:10 | The role of windage, currents and Stokes drift on the distribution of plastic litter released from the Indian rivers \| Vasimilla Suneel (online)                                                      |
+|           | 12:10–12:20 | Floating macro-plastics retention in Baltic semi-enclosed coastal systems: A model study under different wind conditions \| Bruna De Ramos                                                             |
+|           | 12:20–13:30 | Lunch                                                                                                                                                                                                  |
+|           | 13:30–13:40 | Larval pathways of Aristeus antennatus revealed by Lagrangian dynamics and network theory \| Ignacio Martínez Caballero                                                                                |
+|           | 13:40–13:50 | Individual-Based Lagrangian Modelling of Ecklonia maxima Dispersal Along the South African Coast \| Ross Coppin                                                                                        |
+|           | 13:50–14:00 | Eukaryotic phytoplankton are sustained by eddies and lateral mixing in the open ocean \| Alexandra Jones-Kellett                                                                                       |
+|           | 14:00–14:10 | Particulate organic carbon export in the Amazon River Plume \| Danilo Augusto Silva                                                                                                                    |
+|           | 14:10–14:20 | Modelling the spatial bound of an eDNA signal in the marine environment - the effect of oceanographic conditions \| Tiago Silva                                                                        |
+|           | 14:20–14:30 | Larval dispersion and connectivity in the south-central Tyrrhenian Sea: a Lagrangian modeling approach using OceanParcels \| Gianluca Liguori                                                          |
+|           | 14:30–14:40 | Towards Operational Readiness: A multi-model forcing system for oil spill monitoring in the Mediterranean Sea \| Beatrice Maddalena Scotto                                                             |
+|           | 14:40–14:50 | Optimizing Big Data Preprocessing Through Prompt Engineering: Toward a New Paradigm of Foundation Model Pipelines \| Arin Dewangan                                                                     |
+|           | 14:50–15:30 | Tea break                                                                                                                                                                                              |
+|           | 15:30–15:40 | Surface Dispersion of Particles Released in the Port of Genoa: A Scenario-Based Lagrangian Analysis \| Mattia Scovenna                                                                                 |
+|           | 15:40–15:50 | Cross-disciplinary applications of particle tracking in the Greater Agulhas System \| Michael Hart-Davis (online)                                                                                      |
+|           | 15:50–16:00 | VirtualShip for simulating in-class oceanographic fieldwork anywhere in the global ocean \| Jamie Atkins                                                                                               |
+|           | 16:00–16:10 | Safe seas for manatees: Identifying Optimal Release Windows Using Ocean Reanalysis Simulations \| Iury Simoes-Sousa (online)                                                                           |
+|           | 16:10–17:00 | Discussion, reflection and wrap-up \| All attending                                                                                                                                                    |
+|           | Evening     | Party (in Utrecht)                                                                                                                                                                                     |
 
 See [this page](/blog/10year-event-online-attendance) for information on how to join online.
 
@@ -83,6 +76,14 @@ See [this page](/blog/10year-event-online-attendance) for information on how to 
 
 The Parcels anniversary event is financially supported by the Dutch Research Council NWO, under the project "Tracing Marine Macroplastics by Unraveling the Ocean’s Multiscale Transport Processes" with file
 number VI.C.222.025.
+
+## Background of the event
+
+Michael Lange committed [b2ae2fd](https://github.com/OceanParcels/Parcels/commit/b2ae2fd44979c125fbc21f2c939289db62dc4816) on 29 September 2015, and we’ve come a long way since then (we didn’t even have an acronym at that point!).
+
+[More than 200 articles have been published using Parcels](/papers-citing-parcels#papers-citing-parcels), on topics ranging from winds on Jupiter (the planet) and iceberg melt to AUV steering and tuna (the fish) behaviour.
+
+![Parcels 10 year anniversary event banner](/posts/10year-event/anniversary-image.png)
 
 ## Background of the event
 


### PR DESCRIPTION
Responding to https://github.com/OceanParcels/oceanparcels_website/pull/205#issue-3386490495, this PR adds support for [GitHub flavoured markdown](https://github.github.com/gfm/) via [remark-gfm](https://github.com/remarkjs/remark-gfm). This includes table support - and will make it easier to write blog posts for those familiar with GitHub markdown syntax.

I've updated the event schedule to use a table, which I think looks better (particularly for the second day which has more talks and longer titles).

Before:

<img width="541" height="736" alt="image" src="https://github.com/user-attachments/assets/ea383932-013c-48d4-b032-ffaeda4c0d3b" />


After:

<img width="569" height="749" alt="image" src="https://github.com/user-attachments/assets/e4a9a0be-6a56-47fa-9578-b2cf58b02fee" />
